### PR TITLE
Create token_limit argument

### DIFF
--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -76,7 +76,7 @@ async def process_response(uid: int, async_generator: Awaitable):
         )
 
         failed_synapse = StreamPromptingSynapse(
-            roles=["user"], messages=["failure"], completion=""
+            roles=["user"], messages=["failure"], completion="", max_tokens=0
         )
 
         return failed_synapse
@@ -115,7 +115,7 @@ async def handle_response(responses: Dict[int, Awaitable]) -> List[StreamResult]
         # If the result is an exception, the response was unsuccessful and the stream result is added with the exception and an empty synapse
         elif isinstance(result, BaseException):
             failed_synapse = StreamPromptingSynapse(
-                roles=["user"], messages=["failure"], completion=""
+                roles=["user"], messages=["failure"], completion="", max_tokens=0
             )
             mapped_results.append(
                 StreamResult(synapse=failed_synapse, exception=result, uid=uid)
@@ -196,7 +196,7 @@ async def run_step(
     # Directly call dendrite and process responses in parallel
     streams_responses = await self.dendrite(
         axons=axons,
-        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge]), max_tokens  = agent.task.token_limit[1],
+        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge], max_tokens  = agent.task.token_limit[1]),
         timeout=timeout,
         deserialize=False,
         streaming=True,

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -196,7 +196,7 @@ async def run_step(
     # Directly call dendrite and process responses in parallel
     streams_responses = await self.dendrite(
         axons=axons,
-        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge], max_tokens  = agent.task.token_limit[1]),
+        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge], max_tokens  = agent.task.token_limit),
         timeout=timeout,
         deserialize=False,
         streaming=True,

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -196,7 +196,7 @@ async def run_step(
     # Directly call dendrite and process responses in parallel
     streams_responses = await self.dendrite(
         axons=axons,
-        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge]),
+        synapse=StreamPromptingSynapse(roles=["user"], messages=[agent.challenge]), max_tokens  = agent.task.token_limit[1],
         timeout=timeout,
         deserialize=False,
         streaming=True,

--- a/prompting/llms/vllm_llm.py
+++ b/prompting/llms/vllm_llm.py
@@ -101,9 +101,10 @@ class vLLMPipeline(BasePipeline):
         temperature = model_kwargs.get("temperature", 0.8)
         top_p = model_kwargs.get("top_p", 0.95)
         max_tokens = model_kwargs.get("max_tokens", 256)
+        min_tokens = model_kwargs.get("min_tokens", 0)
 
         sampling_params = SamplingParams(
-            temperature=temperature, top_p=top_p, max_tokens=max_tokens
+            temperature=temperature, top_p=top_p, max_tokens=max_tokens, min_tokens=min_tokens,
         )
         output = self.llm.generate(composed_prompt, sampling_params, use_tqdm=True)
         response = output[0].outputs[0].text
@@ -174,7 +175,8 @@ class vLLM_LLM(BaseLLM):
         composed_prompt = self._make_prompt(messages)
         model_kwargs = self.model_kwargs.copy()
         if token_limit:
-            model_kwargs["max_tokens"] = token_limit
+            model_kwargs["min_tokens"] = token_limit[0]
+            model_kwargs["max_tokens"] = token_limit[1]
         response = self.llm_pipeline(composed_prompt, **model_kwargs)
 
         bt.logging.info(

--- a/prompting/llms/vllm_llm.py
+++ b/prompting/llms/vllm_llm.py
@@ -175,8 +175,7 @@ class vLLM_LLM(BaseLLM):
         composed_prompt = self._make_prompt(messages)
         model_kwargs = self.model_kwargs.copy()
         if token_limit:
-            model_kwargs["min_tokens"] = token_limit[0]
-            model_kwargs["max_tokens"] = token_limit[1]
+            model_kwargs["max_tokens"] = token_limit
         response = self.llm_pipeline(composed_prompt, **model_kwargs)
 
         bt.logging.info(

--- a/prompting/protocol.py
+++ b/prompting/protocol.py
@@ -151,6 +151,8 @@ class StreamPromptingSynapse(bt.StreamingSynapse):
                           product or result of the streaming process.
     - `required_hash_fields` (List[str]): A list of fields that are required for the hash.
 
+    - `max_tokens` (int): The maximum number of tokens to process in a single streaming response.
+
     Methods:
     - `process_streaming_response`: This method asynchronously processes the incoming streaming response by decoding
                                     the tokens and accumulating them in the `completion` attribute.
@@ -184,6 +186,9 @@ class StreamPromptingSynapse(bt.StreamingSynapse):
         description="A list of required fields for the hash.",
         allow_mutation=False,
     )
+
+    max_tokens: int = pydantic.Field(
+        ..., title="Max Tokens", description="The maximum number of tokens that a miner should send." ) 
 
     completion: str = pydantic.Field(
         "",

--- a/prompting/protocol.py
+++ b/prompting/protocol.py
@@ -151,7 +151,7 @@ class StreamPromptingSynapse(bt.StreamingSynapse):
                           product or result of the streaming process.
     - `required_hash_fields` (List[str]): A list of fields that are required for the hash.
 
-    - `max_tokens` (int): The maximum number of tokens to process in a single streaming response.
+    - `max_tokens` (int): The maximum number of tokens to generate in a single streaming response.
 
     Methods:
     - `process_streaming_response`: This method asynchronously processes the incoming streaming response by decoding

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -51,7 +51,7 @@ class Task(ABC):
     query_prompt = ""
     cleaner = None
     token_goal = random.choice([128, 256, 512, 1024,])
-    token_limit = [token_goal/2, token_goal]
+    token_limit = [token_goal//2, token_goal]
 
     def __str__(self):
         return f"{self.__class__.__name__}(name={self.name!r}, desc={self.desc!r}, goal={self.goal!r}, query={self.query!r}, reference={self.reference!r}, topic={self.topic!r}, subtopic={self.subtopic!r}, tags={self.tags!r})"

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -50,8 +50,7 @@ class Task(ABC):
     query_system_prompt = ""
     query_prompt = ""
     cleaner = None
-    token_goal = random.choice([128, 256, 512, 1024,])
-    token_limit = [token_goal//2, token_goal]
+    token_limit = random.choice([256, 512, 1024,])
 
     def __str__(self):
         return f"{self.__class__.__name__}(name={self.name!r}, desc={self.desc!r}, goal={self.goal!r}, query={self.query!r}, reference={self.reference!r}, topic={self.topic!r}, subtopic={self.subtopic!r}, tags={self.tags!r})"
@@ -97,7 +96,7 @@ class Task(ABC):
             
             self.reference = self.generate(
                 system=make_system_prompt(),
-                prompt=self.reference_prompt + f"\n Your answer should be {self.token_limit[0]} words long",
+                prompt=self.reference_prompt + f"\n Your answer should be {self.token_limit} words long",
                 pipeline=pipeline,
                 clean=clean,
                 token_limit=self.token_limit,

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -50,7 +50,8 @@ class Task(ABC):
     query_system_prompt = ""
     query_prompt = ""
     cleaner = None
-    token_limit = random.choice([None, 256, 512, 1024, 2048])
+    token_goal = random.choice([128, 256, 512, 1024,])
+    token_limit = [token_goal/2, token_goal]
 
     def __str__(self):
         return f"{self.__class__.__name__}(name={self.name!r}, desc={self.desc!r}, goal={self.goal!r}, query={self.query!r}, reference={self.reference!r}, topic={self.topic!r}, subtopic={self.subtopic!r}, tags={self.tags!r})"

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -97,7 +97,7 @@ class Task(ABC):
             
             self.reference = self.generate(
                 system=make_system_prompt(),
-                prompt=self.reference_prompt + f"\n Your answer should be {token_limit[0]} words long",
+                prompt=self.reference_prompt + f"\n Your answer should be {self.token_limit[0]} words long",
                 pipeline=pipeline,
                 clean=clean,
                 token_limit=self.token_limit,

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -97,7 +97,7 @@ class Task(ABC):
             
             self.reference = self.generate(
                 system=make_system_prompt(),
-                prompt=self.reference_prompt,
+                prompt=self.reference_prompt + f"\n Your answer should be {token_limit[0]} words long",
                 pipeline=pipeline,
                 clean=clean,
                 token_limit=self.token_limit,

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -26,7 +26,7 @@ async def mock_dendrite_call(delay=1, **kwargs):
     asyncio.run(asyncio.sleep(delay))
     
     async def async_fn_mock():                   
-        mock_synapse = StreamPromptingSynapse(roles=["user"], messages=[""])
+        mock_synapse = StreamPromptingSynapse(roles=["user"], messages=[""], max_tokens = 256,)
         mock_synapse.completion = "Fake response"
             
         yield mock_synapse

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -55,6 +55,7 @@ def test_mock_streaming(timeout: float):
     synapse = StreamPromptingSynapse(
         roles=["user"],
         messages=messages,
+        max_tokens=256,
     )
 
     async def get_responses(


### PR DESCRIPTION
Create token_limit, which when generating a reference answer, overrides the otherwise universal max_tokens argument defined by the llm object.