### PR TITLE
Validator Llama3 70B GPTQ (8-bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ For ease of use, you can run the scripts as well with PM2. Installation of PM2 i
 sudo apt update && sudo apt install jq && sudo apt install npm && sudo npm install pm2 -g && pm2 update
 ``` 
 
-Example of running a SOLAR miner: 
+Example of running a Llama3 miner: 
 ```bash
-pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 1  --subtensor.network finney --wallet.name my_wallet --wallet.hotkey m1 --neuron.model_id casperhansen/llama-3-70b-instruct-awq --axon.port 21988 --logging.debug 
+pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 1  --subtensor.network finney --wallet.name my_wallet --wallet.hotkey m1 --neuron.model_id MaziyarPanahi/Meta-Llama-3-70B-Instruct-GPTQ --axon.port 21988 --logging.debug
 ``` 
 
 # Testnet 
@@ -90,7 +90,7 @@ In order to run on testnet, you will need to go through the same hotkey registra
 To run:
 
 ```bash
-pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 61  --subtensor.network test --wallet.name my_test_wallet --wallet.hotkey m1 --neuron.model_id casperhansen/llama-3-70b-instruct-awq --axon.port 21988 --logging.debug 
+pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 61  --subtensor.network test --wallet.name my_test_wallet --wallet.hotkey m1 --neuron.model_id MaziyarPanahi/Meta-Llama-3-70B-Instruct-GPTQ --axon.port 21988 --logging.debug 
 ```
 
 # Limitations

--- a/prompting/llms/vllm_llm.py
+++ b/prompting/llms/vllm_llm.py
@@ -51,7 +51,6 @@ def load_vllm_pipeline(model_id: str, device: str, gpus: int, max_allowed_memory
             f"Error loading the VLLM pipeline within {max_allowed_memory_in_gb}GB: {e}"
         )
         raise e
-        
 
 
 class vLLMPipeline(BasePipeline):

--- a/prompting/llms/vllm_llm.py
+++ b/prompting/llms/vllm_llm.py
@@ -39,7 +39,7 @@ def load_vllm_pipeline(model_id: str, device: str, gpus: int, max_allowed_memory
 
     try:
         # Attempt to initialize the LLM
-        llm = LLM(model=model_id, gpu_memory_utilization = gpu_mem_utilization, quantization="AWQ", tensor_parallel_size=gpus)
+        llm = LLM(model=model_id, gpu_memory_utilization = gpu_mem_utilization, quantization="gptq", tensor_parallel_size=gpus)
         # This solution implemented by @bkb2135 sets the eos_token_id directly for efficiency in vLLM usage.
         # This approach avoids the overhead of loading a tokenizer each time the custom eos token is needed.
         # Using the Hugging Face pipeline, the eos token specific to llama models was fetched and saved (128009).


### PR DESCRIPTION
## Changes
  - Set default validator model to Llama3 70B GPTQ (8-bit).

## Tests
  - [W&B validator testnet run](https://wandb.ai/opentensor-dev/alpha-validators/runs/c61s04zb).
  
## Benchmarks
  - [x] Reported in the comment section.