### PR TITLE
Sn1 5 push pr to reduce tasks for multi turn qa

### DIFF
--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -36,6 +36,8 @@ from transformers import PreTrainedTokenizerFast as Tokenizer
 from prompting.utils.uids import get_random_uids
 from dataclasses import dataclass
 
+SINGLE_TURN_TASKS = ['sentiment', 'translation']
+
 @async_log
 async def generate_reference(agent):
     loop = asyncio.get_running_loop()
@@ -321,8 +323,7 @@ async def forward(self):
             if random.random()<0.5 or turn>=1:
                 break
 
-            single_turn_tasks = ['sentiment', 'translation']
-            if task.name in single_turn_tasks:
+            if task.name in SINGLE_TURN_TASKS:
                 break
 
             history = '\n'.join([f"{role}: {message}" for role, message in zip(roles, messages)])

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2,12 +2,13 @@ import pytest
 import asyncio
 import sys
 from functools import partial
-from prompting.forward import run_step
+from prompting.forward import run_step, SINGLE_TURN_TASKS
 from neurons.validator import Validator
 from prompting.tasks import QuestionAnsweringTask
 from .fixtures.task import WIKI_CONTEXT
 from prompting.agent import HumanAgent
 from prompting.protocol import StreamPromptingSynapse
+from prompting.tasks import TASKS
 
 sys.argv = [__file__, "--mock", "--wandb.off", "--neuron.tasks", "qa"]
 mock_neuron = Validator()
@@ -59,3 +60,7 @@ def test_generate_reference_parallel_to_dendrite(
     assert network_and_reference_gen_time == pytest.approx(
         expected_forward_time, abs=1#0.1
     )
+
+def test_single_turn_tasks_in_tasks():
+    # Test that SINGLE_TURN_TASKS is a subset of TASKS.keys()
+    assert set(SINGLE_TURN_TASKS).issubset(set(TASKS.keys()))


### PR DESCRIPTION
Disable multi-turn for sentiment and translation as they lead to very low quality followups