### PR TITLE
Restart on bittensor error

### DIFF
--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/prompting/base/neuron.py
+++ b/prompting/base/neuron.py
@@ -56,7 +56,9 @@ class BaseNeuron(ABC):
 
     @property
     def block(self):
-        return ttl_get_block(self)
+        self._block = ttl_get_block(self)
+        self.latest_block = self._block
+        return self._block
 
     def __init__(self, config=None):
         base_config = copy.deepcopy(config or BaseNeuron._config())

--- a/prompting/base/validator.py
+++ b/prompting/base/validator.py
@@ -129,12 +129,12 @@ class BaseValidatorNeuron(BaseNeuron):
                 f"Running validator on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
             )
 
-        bt.logging.info(f"Validator starting at block: {self.block}")
+        bt.logging.info(f"Validator starting at block: {self.latest_block}")
 
         # This loop maintains the validator's operations until intentionally stopped.
         try:
             while True:
-                bt.logging.info(f"step({self.step}) block({self.block})")
+                bt.logging.info(f"step({self.step}) block({self.latest_block})")
 
                 forward_timeout = self.config.neuron.forward_max_time
                 try:

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -30,6 +30,7 @@ from prompting.protocol import StreamPromptingSynapse
 from prompting.rewards import RewardResult
 from prompting.tasks import QuestionAnsweringTask
 from prompting.utils.uids import get_random_uids
+from prompting.utils.exceptions import BittensorError
 from prompting.utils.logging import log_event
 from prompting.utils.misc import async_log, serialize_exception_to_string
 from transformers import PreTrainedTokenizerFast as Tokenizer

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -337,7 +337,12 @@ async def forward(self):
             roles.append("user")
             messages.append(agent.challenge)
             turn += 1
-
+        except BittensorError as e:
+            bittensor_error = serialize_exception_to_string(e)
+            bt.logging.error(
+                f"An error was raised from the Bittensor package. Ending validator. \n {bittensor_error}"
+            )
+            sys.exit(1)
         except BaseException as e:
             unexpected_errors = serialize_exception_to_string(e)
             bt.logging.error(

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -243,7 +243,7 @@ async def run_step(
     # Log the step event.
     event = {
         "best": best_response,
-        "block": self.block,
+        "block": self.latest_block,
         "step": self.step,
         "step_time": time.time() - start_time,        
         **agent.__state_dict__(full=self.config.neuron.log_full),

--- a/prompting/utils/exceptions.py
+++ b/prompting/utils/exceptions.py
@@ -4,3 +4,10 @@ class MaxRetryError(Exception):
     def __init__(self, message="Maximum number of retries exceeded"):
         self.message = message
         super().__init__(self.message)
+
+class BittensorError(Exception):
+    """Exception raised when an error is raised from the bittensor package"""
+
+    def __init__(self, message = "An error from the Bittensor package occured"):
+        self.message = message 
+        super().__init__(self.message)

--- a/prompting/utils/misc.py
+++ b/prompting/utils/misc.py
@@ -23,7 +23,7 @@ import bittensor as bt
 from math import floor
 from typing import Callable, Any
 from functools import lru_cache, update_wrapper
-from prompting.utils.exceptions import BittensorErrorException
+from prompting.utils.exceptions import BittensorError
 
 
 # LRU Cache with TTL
@@ -114,7 +114,7 @@ def ttl_get_block(self) -> int:
     try:
         return self.subtensor.get_current_block()
     except Exception as e:
-        raise BittensorErrorException(f"Bittensor error: {str(e)}") from e
+        raise BittensorError(f"Bittensor error: {str(e)}") from e
 
 
 def async_log(func):

--- a/prompting/utils/misc.py
+++ b/prompting/utils/misc.py
@@ -23,6 +23,7 @@ import bittensor as bt
 from math import floor
 from typing import Callable, Any
 from functools import lru_cache, update_wrapper
+from prompting.utils.exceptions import BittensorErrorException
 
 
 # LRU Cache with TTL
@@ -110,7 +111,10 @@ def ttl_get_block(self) -> int:
 
     Note: self here is the miner or validator instance
     """
-    return self.subtensor.get_current_block()
+    try:
+        return self.subtensor.get_current_block()
+    except Exception as e:
+        raise BittensorErrorException(f"Bittensor error: {str(e)}") from e
 
 
 def async_log(func):


### PR DESCRIPTION
Restart when an error is encountered in the get_block function. Errors when making substrate calls usually result in the validator failing quietly, often requiring a manual restart. This PR is intended to catch errors originating from calls to the Bittensor package, raise them as Bittensor Errors, and then restart.