### PR TITLE
Hotfix undefined challenge_time

### DIFF
--- a/prompting/agent.py
+++ b/prompting/agent.py
@@ -27,8 +27,6 @@ from prompting.persona import Persona, create_persona
 
 from transformers import Pipeline
 
-RETRY_LIMIT = 3
-
 
 class HumanAgent(vLLM_LLM):
     "Agent that impersonates a human user and makes queries based on its goal."
@@ -83,14 +81,7 @@ class HumanAgent(vLLM_LLM):
         if begin_conversation:
             bt.logging.info("🤖 Generating challenge query...")
             # initiates the conversation with the miner
-            for i in range(RETRY_LIMIT):
-                self.challenge = self.challenge_time()
-                if not self.challenge:
-                    bt.logging.error("❌ Generated an empty challenge. Retrying...")
-                else:
-                    break
-            if not self.challenge:
-                bt.logging.error("Max retries reached. Skipping task.")
+            self.challenge = self.create_challenge()
 
     def create_challenge(self) -> str:
         """Creates the opening question of the conversation which is based on the task query but dressed in the persona of the user."""

--- a/prompting/organic/organic_scoring_prompting.py
+++ b/prompting/organic/organic_scoring_prompting.py
@@ -283,7 +283,7 @@ class OrganicScoringPrompting(OrganicScoringBase):
         agent = HumanAgent(
             task=task,
             llm_pipeline=self._val.llm_pipeline,
-            begin_conversation=True,
+            begin_conversation=False,
             system_prompt=make_system_prompt(),
         )
         reward_result = RewardResult(

--- a/prompting/organic/organic_scoring_prompting.py
+++ b/prompting/organic/organic_scoring_prompting.py
@@ -283,7 +283,7 @@ class OrganicScoringPrompting(OrganicScoringBase):
         agent = HumanAgent(
             task=task,
             llm_pipeline=self._val.llm_pipeline,
-            begin_conversation=False,
+            begin_conversation=True,
             system_prompt=make_system_prompt(),
         )
         reward_result = RewardResult(


### PR DESCRIPTION
## Changes
  - Revert PR with undefined `HumanAgent.challenge_time`: https://github.com/macrocosm-os/prompting/pull/304
  
## Problem Statement
```
13|otf-validator  |   File "/workspace/prompting/prompting/validator.py", line 53, in forward                                                                                     13|otf-validator  |     return await forward(self)
13|otf-validator  |   File "/workspace/prompting/prompting/forward.py", line 285, in forward
13|otf-validator  |     agent = HumanAgent(
13|otf-validator  |   File "/workspace/prompting/prompting/agent.py", line 87, in __init__
13|otf-validator  |     self.challenge = self.challenge_time()
13|otf-validator  | AttributeError: 'HumanAgent' object has no attribute 'challenge_time'
```