### PR TITLE
v2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <picture>
     <source srcset="./assets/macrocosmos-white.png"  media="(prefers-color-scheme: dark)">
-    <img src="macrocosmos-white.png">
-</picture>
-
-<picture>
     <source srcset="./assets/macrocosmos-black.png"  media="(prefers-color-scheme: light)">
     <img src="macrocosmos-black.png">
 </picture>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ If you are running a miner, you will also need to uninstall uvloop.
 pip uninstall uvloop -y
 ```
 
+If you are running a validator, logging in to Hugging Face is required:
+```shell
+huggingface-cli login
+```
+You also need to accept the License Agreement for the LMSYS-Chat-1M dataset: https://huggingface.co/datasets/lmsys/lmsys-chat-1m
+
 </div>
 
 # Compute Requirements

--- a/install.sh
+++ b/install.sh
@@ -5,3 +5,12 @@ pip uninstall mathgenerator -y
 
 # Installing package from the current directory
 pip install -e .
+
+# Updating the package list and installing jq and npm
+apt update && apt install -y jq npm
+
+# Installing PM2 globally
+npm install pm2 -g
+
+# Updating PM2
+pm2 update

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ pip uninstall mathgenerator -y
 # Installing package from the current directory
 pip install -e .
 
+# Uninstall uvloop
+pip uninstall uvloop -y
+
 # Updating the package list and installing jq and npm
 apt update && apt install -y jq npm
 

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.5.2"
+__version__ = "2.6.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,7 +16,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-
 __version__ = "2.6.0"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
+
 __version__ = "2.6.0"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/prompting/agent.py
+++ b/prompting/agent.py
@@ -18,10 +18,11 @@ import textwrap
 import time
 import bittensor as bt
 from dataclasses import asdict
-from prompting.tasks import Task
-from prompting.llms import HuggingFaceLLM, vLLM_LLM
-from prompting.cleaners.cleaner import CleanerPipeline
+from typing import Optional
 
+from prompting.tasks import Task
+from prompting.llms import vLLM_LLM
+from prompting.cleaners.cleaner import CleanerPipeline
 from prompting.persona import Persona, create_persona
 
 from transformers import Pipeline
@@ -44,7 +45,7 @@ class HumanAgent(vLLM_LLM):
         """This is a roleplaying game where you are impersonating {mood} human user with a specific persona. As a human, you are using AI assistant to {desc} related to {topic} ({subtopic}) in a {tone} tone. You don't need to greet the assistant or be polite, unless this is part of your persona. The spelling and grammar of your messages should also reflect your persona.
 
         Your singular focus is to use the assistant to {goal}: {query}
-    """
+        """
     )
 
     def __init__(
@@ -54,10 +55,8 @@ class HumanAgent(vLLM_LLM):
         system_template: str = None,
         persona: Persona = None,
         begin_conversation=True,
+        system_prompt: Optional[str] = None,
     ):
-        if persona is None:
-            persona = create_persona()
-
         self.persona = persona
         self.task = task
         self.llm_pipeline = llm_pipeline
@@ -65,11 +64,15 @@ class HumanAgent(vLLM_LLM):
         if system_template is not None:
             self.system_prompt_template = system_template
 
-        self.system_prompt = self.system_prompt_template.format(
-            mood=self.persona.mood,
-            tone=self.persona.tone,
-            **self.task.__state_dict__(),  # Adds desc, subject, topic
-        )
+        self.system_prompt = system_prompt
+        if self.system_prompt is None:
+            if self.persona is None:
+                self.persona = create_persona()
+            self.system_prompt = self.system_prompt_template.format(
+                mood=self.persona.mood,
+                tone=self.persona.tone,
+                **self.task.__state_dict__(),  # Adds desc, subject, topic
+            )
 
         super().__init__(
             llm_pipeline=llm_pipeline,

--- a/prompting/agent.py
+++ b/prompting/agent.py
@@ -27,8 +27,6 @@ from prompting.persona import Persona, create_persona
 
 from transformers import Pipeline
 
-RETRY_LIMIT = 3
-
 
 class HumanAgent(vLLM_LLM):
     "Agent that impersonates a human user and makes queries based on its goal."
@@ -83,14 +81,7 @@ class HumanAgent(vLLM_LLM):
         if begin_conversation:
             bt.logging.info("🤖 Generating challenge query...")
             # initiates the conversation with the miner
-            for i in range(RETRY_LIMIT):
-                self.challenge = self.challenge_time()
-                if not self.challenge:
-                    bt.logging.error("❌ Generated an empty challenge. Retrying...")
-                else:
-                    break
-            if not self.challenge:
-                bt.logging.error("Max retries reached. Skipping task.")
+            self.challenge = self.create_challenge()
 
     def create_challenge(self) -> str:
         """Creates the opening question of the conversation which is based on the task query but dressed in the persona of the user."""

--- a/prompting/base/neuron.py
+++ b/prompting/base/neuron.py
@@ -57,7 +57,9 @@ class BaseNeuron(ABC):
 
     @property
     def block(self):
-        return ttl_get_block(self)
+        self._block = ttl_get_block(self)
+        self.latest_block = self._block
+        return self._block
 
     def __init__(self, config=None):
         base_config = copy.deepcopy(config or BaseNeuron._config())

--- a/prompting/base/neuron.py
+++ b/prompting/base/neuron.py
@@ -17,6 +17,7 @@
 
 import copy
 import sys
+import threading
 
 import bittensor as bt
 

--- a/prompting/base/validator.py
+++ b/prompting/base/validator.py
@@ -146,12 +146,12 @@ class BaseValidatorNeuron(BaseNeuron):
                 f"Running validator on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
             )
 
-        bt.logging.info(f"Validator starting at block: {self.block}")
+        bt.logging.info(f"Validator starting at block: {self.latest_block}")
 
         # This loop maintains the validator's operations until intentionally stopped.
         try:
             while True:
-                bt.logging.info(f"step({self.step}) block({self.block})")
+                bt.logging.info(f"step({self.step}) block({self.latest_block})")
 
                 forward_timeout = self.config.neuron.forward_max_time
                 try:

--- a/prompting/conversation.py
+++ b/prompting/conversation.py
@@ -41,8 +41,6 @@ def create_task(
     dataset = DATASETS.get(dataset_name, None)
     if dataset is None:
         raise ValueError(f"Dataset {dataset_name} not found")
-    elif task_name == SummarizationTask.name:
-        dataset = dataset(selector = "all")
     else:
         dataset = dataset()
         
@@ -50,6 +48,12 @@ def create_task(
         return task(            
             translation_pipeline=translation_pipeline,
             context=dataset.next()
+        )
+    elif task_name == SummarizationTask.name:
+        return task(
+        llm_pipeline=llm_pipeline,
+        context=dataset.next(selector = "all"),
+        create_reference=create_reference,
         )
 
     return task(

--- a/prompting/conversation.py
+++ b/prompting/conversation.py
@@ -1,6 +1,6 @@
 import random
 from transformers import Pipeline
-from prompting.tasks import Task, TASKS, TranslationPipeline, TranslationTask
+from prompting.tasks import Task, TASKS, TranslationPipeline, TranslationTask, SummarizationTask
 from prompting.tools import Selector, DATASETS
 from prompting.task_registry import TASK_REGISTRY
 
@@ -41,6 +41,8 @@ def create_task(
     dataset = DATASETS.get(dataset_name, None)
     if dataset is None:
         raise ValueError(f"Dataset {dataset_name} not found")
+    elif task_name == SummarizationTask.name:
+        dataset = dataset(selector = "all")
     else:
         dataset = dataset()
         

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -31,6 +31,7 @@ from prompting.protocol import StreamPromptingSynapse
 from prompting.rewards import RewardResult
 from prompting.tasks import QuestionAnsweringTask
 from prompting.utils.uids import get_random_uids
+from prompting.utils.exceptions import BittensorError
 from prompting.utils.logging import log_event
 from prompting.utils.misc import async_log, serialize_exception_to_string
 from transformers import PreTrainedTokenizerFast as Tokenizer
@@ -238,7 +239,7 @@ async def run_step(
     # Log the step event.
     event = {
         "best": best_response,
-        "block": self.block,
+        "block": self.latest_block,
         "step": self.step,
         "step_time": time.time() - start_time,
         **agent.__state_dict__(full=self.config.neuron.log_full),
@@ -333,7 +334,12 @@ async def forward(self):
             roles.append("user")
             messages.append(agent.challenge)
             turn += 1
-
+        except BittensorError as e:
+            bittensor_error = serialize_exception_to_string(e)
+            bt.logging.error(
+                f"An error was raised from the Bittensor package. Ending validator. \n {bittensor_error}"
+            )
+            sys.exit(1)
         except BaseException as e:
             unexpected_errors = serialize_exception_to_string(e)
             bt.logging.error(

--- a/prompting/llms/vllm_llm.py
+++ b/prompting/llms/vllm_llm.py
@@ -14,11 +14,10 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import gc
+import threading
 import time
-import torch
 import bittensor as bt
-from typing import List, Dict
+from typing import List, Dict, Optional, Any
 from vllm import LLM, SamplingParams
 from prompting.cleaners.cleaner import CleanerPipeline
 from prompting.llms import BasePipeline, BaseLLM
@@ -55,6 +54,8 @@ def load_vllm_pipeline(model_id: str, device: str, gpus: int, max_allowed_memory
 
 
 class vLLMPipeline(BasePipeline):
+    _LOCK = threading.Lock()
+
     def __init__(
         self,
         model_id: str,
@@ -81,7 +82,8 @@ class vLLMPipeline(BasePipeline):
         sampling_params = SamplingParams(
             temperature=temperature, top_p=top_p, max_tokens=max_tokens
         )
-        output = self.llm.generate(composed_prompt, sampling_params, use_tqdm=True)
+        with self._LOCK:
+            output = self.llm.generate(composed_prompt, sampling_params, use_tqdm=True)
         response = output[0].outputs[0].text
         return response
 
@@ -111,6 +113,30 @@ class vLLM_LLM(BaseLLM):
             "assistant": "<|start_header_id|>assistant<|end_header_id|>\n{{{{ {} }}}}<|eot_id|>",
             "end": "<|start_header_id|>assistant<|end_header_id|>",
         }
+
+    def query_conversation(
+        self,
+        messages: list[str],
+        roles: list[str],
+        cleaner: Optional[CleanerPipeline] = None,
+    ):
+        """Query LLM with the given lists of conversation history and roles
+        
+        Args:
+            messages (list[str]): List of messages in the conversation.
+            roles (list[str]): List of roles for each message.
+            cleaner (Optional[CleanerPipeline], optional): Cleaner pipeline to use, if any.
+        """
+        assert len(messages) == len(roles), "Length of messages and roles must be the same"
+        inputs: list[dict[str, Any]] = [{"content": self.system_prompt, "role": "system"}]
+        for role, message in zip(roles, messages):
+            inputs.append({"content": message, "role": role})
+
+        t0 = time.perf_counter()
+        response = self.forward(messages=inputs)
+        response = self.clean_response(cleaner, response)
+        self.times.extend((0, time.perf_counter() - t0))
+        return response
 
     def query(
         self,

--- a/prompting/organic/organic_scoring_prompting.py
+++ b/prompting/organic/organic_scoring_prompting.py
@@ -1,0 +1,351 @@
+import asyncio
+import json
+import time
+from functools import partial
+from typing import Any, AsyncGenerator, Literal, Sequence, Tuple, Union
+
+import bittensor as bt
+import torch
+import numpy as np
+from organic_scoring import OrganicScoringBase
+from organic_scoring.synth_dataset import SynthDatasetBase
+from starlette.types import Send
+from typing_extensions import override
+from bittensor.dendrite import dendrite
+
+from prompting.agent import HumanAgent
+from prompting.base.neuron import BaseNeuron
+from prompting.cleaners.cleaner import CleanerPipeline
+from prompting.dendrite import DendriteResponseEvent, SynapseStreamResult
+from prompting.forward import handle_response
+from prompting.llms.vllm_llm import vLLM_LLM
+from prompting.organic.organic_task import OrganicTask
+from prompting.organic.synth_organic_task import SynthOrganicTask
+from prompting.protocol import StreamPromptingSynapse
+from prompting.rewards.pipeline import RewardPipeline
+from prompting.rewards.reward import RewardResult
+from prompting.tasks.task import make_system_prompt
+from prompting.utils.logging import log_event
+from prompting.utils.uids import get_random_uids, get_uids
+
+
+class OrganicScoringPrompting(OrganicScoringBase):
+    def __init__(
+        self,
+        axon: bt.axon,
+        synth_dataset: Union[SynthDatasetBase, Sequence[SynthDatasetBase]],
+        trigger_frequency: Union[float, int],
+        trigger: Literal["seconds", "steps"],
+        validator: BaseNeuron,
+        trigger_frequency_min: Union[float, int] = 5,
+        trigger_scaling_factor: Union[float, int] = 5,
+    ):
+        """Organic Scoring implementation.
+
+        Organic scoring runs in a separate `asyncio` task and is triggered by a timer or a step counter.
+
+        Process Workflow:
+        1. Trigger Check: Upon triggering the rewarding process, the system checks if the organic queue is empty.
+            If the queue is empty, synthetic datasets are used to bootstrap the organic scoring mechanism.
+            Otherwise, samples from the organic queue are utilized.
+        2. Data Processing: The sampled data is concurrently passed to the `_query_miners` and `_generate_reference`
+            methods.
+        3. Reward Generation: After receiving responses from miners and any reference data, the information
+            is processed by the `_generate_rewards` method.
+        4. Weight Setting: The generated rewards are then applied through the `_set_weights` method.
+        5. Logging: Finally, the results can be logged using the `_log_results` method, along with all relevant data
+            provided as arguments, and default time elapsed on each step of rewarding process.
+        """
+        super().__init__(
+            axon=axon,
+            synth_dataset=synth_dataset,
+            trigger_frequency=trigger_frequency,
+            trigger=trigger,
+            trigger_frequency_min=trigger_frequency_min,
+            trigger_scaling_factor=trigger_scaling_factor,
+        )
+        self._val = validator
+        # Organic scoring reward pipeline.
+        self._reward_pipeline = RewardPipeline(
+            selected_tasks=[OrganicTask.name, SynthOrganicTask.name],
+            device=self._val.device,
+            available_tasks={
+                OrganicTask.name: OrganicTask,
+                SynthOrganicTask.name: SynthOrganicTask,
+            },
+        )
+
+    @override
+    async def _priority_fn(self, synapse: StreamPromptingSynapse) -> float:
+        """Priority function for the axon."""
+        return 10000000.0
+
+    @override
+    async def _blacklist_fn(self, synapse: StreamPromptingSynapse) -> Tuple[bool, str]:
+        """Blacklist function for the axon."""
+        # ! DO NOT CHANGE `Tuple` return type to `tuple`, it will break the code (bittensor internal signature checks).
+        # We expect the API to be run with one specific hotkey (e.g. OTF).
+        return synapse.dendrite.hotkey != self._val.config.neuron.organic_whitelist_hotkey, ""
+
+    @override
+    async def _on_organic_entry(self, synapse: StreamPromptingSynapse) -> StreamPromptingSynapse:
+        """Organic query handle."""
+        bt.logging.info(f"[Organic] Received from {synapse.dendrite.hotkey}, IP: {synapse.dendrite.ip}")
+
+        uids = get_uids(
+            self._val,
+            sampling_mode=self._val.config.neuron.organic_sampling_mode,
+            k=self._val.config.neuron.organic_sample_size,
+            exclude=[],
+        )
+        uids_list = uids.cpu().tolist()
+        completions: dict[int, dict] = {}
+        token_streamer = partial(
+            self._stream_miner_response,
+            synapse,
+            uids_list,
+            completions,
+        )
+
+        streaming_response = synapse.create_streaming_response(token_streamer)
+        self._organic_queue.add(
+            {
+                "roles": synapse.roles,
+                "messages": synapse.messages,
+                "organic": True,
+                "synapse": synapse,
+                "streaming_response": streaming_response,
+                "uids": uids_list,
+                "completions": completions,
+            }
+        )
+        return streaming_response
+
+    async def _stream_miner_response(
+        self,
+        synapse: StreamPromptingSynapse,
+        uids: list[int],
+        completions: dict[int, dict],
+        send: Send,
+    ):
+        """Stream back miner's responses."""
+        bt.logging.info(f"[Organic] Querying miner UIDs: {uids}")
+        try:
+            async with dendrite(wallet=self._val.wallet) as dend:
+                responses = await dend(
+                    axons=[self._val.metagraph.axons[uid] for uid in uids],
+                    synapse=synapse,
+                    timeout=self._val.config.neuron.organic_timeout,
+                    deserialize=False,
+                    streaming=True,
+                )
+        except Exception as e:
+            bt.logging.error(f"[Organic] Error querying dendrite: {e}")
+            return
+
+        async def stream_miner_chunks(uid: int, chunks: AsyncGenerator):
+            accumulated_chunks: list[str] = []
+            accumulated_chunks_timings: list[float] = []
+            accumulated_tokens_per_chunk: list[int] = []
+            synapse: StreamPromptingSynapse | None = None
+            completions[uid] = {"completed": False}
+            timer_start = time.perf_counter()
+            async for chunk in chunks:
+                try:
+                    if isinstance(chunk, str):
+                        accumulated_chunks.append(chunk)
+                        accumulated_chunks_timings.append(time.perf_counter() - timer_start)
+                        json_chunk = json.dumps({"uid": uid, "chunk": chunk})
+                        await send(
+                            {
+                                "type": "http.response.body",
+                                "body": json_chunk.encode("utf-8"),
+                                "more_body": True,
+                            }
+                        )
+                    elif isinstance(chunk, StreamPromptingSynapse):
+                        synapse = chunk
+                except Exception as e:
+                    bt.logging.error(f"[Organic] Error while streaming chunks: {e}")
+                    break
+            # TODO: Do we need to identify the end of each miner's response?
+            # json_chunk = json.dumps({"uid": uid, "chunk": b"", "completed": True})
+            # await send({"type": "http.response.body", "body": json_chunk, "more_body": False})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            completions[uid]["accumulated_chunks"] = accumulated_chunks
+            completions[uid]["accumulated_chunks_timings"] = accumulated_chunks_timings
+            completions[uid]["accumulated_tokens_per_chunk"] = accumulated_tokens_per_chunk
+            completions[uid]["completed"] = True
+            completions[uid]["synapse"] = synapse
+            # bt.logging.debug(f"[Organic] Streaming {uid}: {''.join(accumulated_chunks)}")
+
+        bt.logging.info(f"[Organic] Awaiting miner streams UIDs: {uids}")
+        await asyncio.gather(
+            *[stream_miner_chunks(uid, chunks) for uid, chunks in zip(uids, responses)],
+            return_exceptions=True,
+        )
+
+    async def _reuse_organic_response(self, sample: dict[str, Any]) -> dict[int, SynapseStreamResult]:
+        """Return a dictionary where the keys are miner UIDs and the values are their corresponding streaming responses.
+
+        This method reuses miner responses for organic data. It waits for each miner to complete within the
+        `neuron.organic_timeout` specified timeout and returns the responses. For miners who exceed the timeout,
+        an empty synapse response is returned.
+
+        Args:
+            sample: Dict where the keys are miner UIDs and the values are the input streaming synapses.
+        """
+        if not sample.get("organic", False):
+            return None
+
+        uids_cpu = sample["uids"]
+        responses: dict[int, SynapseStreamResult] = {}
+        bt.logging.info(f"[Organic] Reusing miner responses for organic data, UIDs: {uids_cpu}")
+
+        async def _check_completion(sample: dict[str, Any], uid: int):
+            while not sample["completions"][uid]["completed"]:
+                await asyncio.sleep(0.1)
+
+        async def _wait_for_completion(uid: int):
+            try:
+                await asyncio.wait_for(
+                    _check_completion(sample, uid),
+                    self._val.config.neuron.organic_timeout,
+                )
+                response = SynapseStreamResult(
+                    accumulated_chunks=sample["completions"][uid]["accumulated_chunks"],
+                    accumulated_chunks_timings=sample["completions"][uid]["accumulated_chunks_timings"],
+                    tokens_per_chunk=sample["completions"][uid]["accumulated_tokens_per_chunk"],
+                    synapse=sample["completions"][uid]["synapse"],
+                    uid=uid,
+                    exception=None,
+                )
+            except asyncio.TimeoutError:
+                response = SynapseStreamResult(
+                    accumulated_chunks=[],
+                    accumulated_chunks_timings=[],
+                    tokens_per_chunk=[],
+                    synapse=None,
+                    uid=uid,
+                    exception=None,
+                )
+            responses[uid] = response
+
+        await asyncio.gather(*[_wait_for_completion(uid) for uid in uids_cpu])
+        return responses
+
+    @override
+    async def _query_miners(self, sample: dict[str, Any]) -> dict[str, SynapseStreamResult]:
+        """Query miners with the given synthetic or organic sample."""
+        if sample.get("organic", False) and not self._val.config.neuron.organic_reuse_response_disabled:
+            responses = await self._reuse_organic_response(sample)
+            return responses
+
+        # Get the list of uids to query.
+        uids = get_random_uids(self._val, k=self._val.config.neuron.organic_sample_size, exclude=None).to(
+            self._val.device
+        )
+        uids_cpu = uids.cpu().tolist()
+        bt.logging.info(f"[Organic] Querying miners with synthetic data, UIDs: {uids_cpu}")
+        streams_responses = await self._val.dendrite.forward(
+            axons=[self._val.metagraph.axons[uid] for uid in uids_cpu],
+            synapse=StreamPromptingSynapse(roles=sample["roles"], messages=sample["messages"]),
+            timeout=self._val.config.neuron.organic_timeout,
+            deserialize=False,
+            streaming=True,
+        )
+        stream_results_dict = dict(zip(uids_cpu, streams_responses))
+        responses = await handle_response(stream_results_dict, self._val.llm_pipeline.tokenizer)
+        return dict(zip(uids_cpu, responses))
+
+    @override
+    async def _generate_rewards(
+        self,
+        sample: dict[str, Any],
+        responses: dict[str, Any],
+        reference: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Generate rewards for the given sample, responses, and reference."""
+        assert reference is not None
+        if sample.get("organic", False):
+            task = OrganicTask(context=sample, reference=reference)
+        else:
+            task = SynthOrganicTask(context=sample, reference=reference)
+        stream_results = list(responses.values())
+        uids_list = list(responses.keys())
+        uids = torch.tensor(uids_list)
+        timeout = self._val.config.neuron.organic_timeout
+        response_event = DendriteResponseEvent(stream_results=stream_results, uids=uids, timeout=timeout)
+
+        bt.logging.debug(f"[Organic] Miner stream results: {stream_results}")
+
+        # Dummy HumanAgent used to reuse existing reward pipeline.
+        agent = HumanAgent(
+            task=task,
+            llm_pipeline=self._val.llm_pipeline,
+            begin_conversation=True,
+            system_prompt=make_system_prompt(),
+        )
+        reward_result = RewardResult(
+            self._reward_pipeline,
+            agent=agent,
+            response_event=response_event,
+            device=self._val.device,
+        )
+        bt.logging.info(f"[Organic] RewardResult: {reward_result}")
+        return {"reward": reward_result, "uids": uids_list, "agent": agent, "organic": sample.get("organic", False)}
+
+    @override
+    async def _set_weights(self, reward: dict[str, Any]):
+        """Set weights based on the given reward."""
+        uids = reward["uids"]
+        reward_result = reward["reward"]
+        if not reward.get("organic", False):
+            reward_result.rewards *= self._val.config.neuron.organic_synth_reward_scale
+
+        uids_to_reward = dict(zip(uids, reward_result.rewards))
+        bt.logging.info(f"[Organic] Rewards for miner's UIDs: {uids_to_reward}")
+        bt.logging.info(f"[Organic] Weight setting enabled: {self._val.config.neuron.organic_set_weights_enabled}")
+        if self._val.config.neuron.organic_set_weights_enabled:
+            self._val.update_scores(reward_result.rewards, uids)
+            # Sync is not needed as it's done in the benchmarks loop.
+            # self._val.sync()
+
+    @override
+    async def _log_results(
+        self,
+        logs: dict[str, Any],
+        reference: str,
+        responses: dict[int, SynapseStreamResult],
+        rewards: dict[str, Any],
+        sample: dict[str, Any],
+        *args,
+        **kwargs,
+    ):
+        logs["block"] = self._val.block
+        logs["step"] = self._val.step
+        # Length of messages is incremented by 2 every step: query and response.
+        logs["turn"] = len(sample["messages"]) // 2
+        completions_len: list[int] = [len(response.synapse.completion) for response in responses.values()]
+        logs["organic_response_mean_chars"] = np.mean(completions_len)
+        logs["organic_response_std_chars"] = np.std(completions_len)
+        logs["organic_reference_chars"] = len(reference)
+        logs.update(rewards["reward"].__state_dict__(full=self._val.config.neuron.log_full))
+        log_event(self._val, logs)
+
+        return logs
+
+    @override
+    async def _generate_reference(self, sample: dict[str, Any]) -> str:
+        """Generate reference for the given organic or synthetic sample."""
+        async with self._val.lock:
+            reference = vLLM_LLM(
+                self._val.llm_pipeline,
+                system_prompt=make_system_prompt(),
+                max_new_tokens=self._val.config.neuron.organic_reference_max_tokens,
+            ).query_conversation(
+                messages=sample["messages"],
+                roles=sample["roles"],
+                cleaner=CleanerPipeline(cleaning_pipeline=[]),
+            )
+        return reference

--- a/prompting/organic/organic_task.py
+++ b/prompting/organic/organic_task.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from prompting.tasks import Task
+
+
+@dataclass
+class OrganicTask(Task):
+    """Task with defined reward and penalty mechanisms for organic prompts."""
+
+    name = "organic"
+    # Use challenge as a query.
+    challenge_type = "query"
+
+    reward_definition = [
+        dict(name="relevance", weight=0.8),
+        dict(name="rouge", ngram="rouge-1", metric="f", weight=0.2),
+    ]
+
+    penalty_definition = [
+        dict(name="relevance", weight=0.5),
+    ]
+
+    cleaning_pipeline = []
+
+    def __init__(self, context: dict, reference: str):
+        self.context = context
+        self.messages = context["messages"]
+        self.roles = context["roles"]
+        self.query = context["messages"][-1]
+        self.topic = "Organic"
+        self.reference = reference
+        self.subtopic = ""
+        self.tags = [""]
+
+    def __str__(self):
+        return f"{self.__class__.__name__}(name={self.name!r}, query={self.query!r}, reference={self.reference!r})"
+
+    def __repr__(self):
+        return str(self)
+
+    def __state_dict__(self, full=False):
+        # Disable any logs for organic queries.
+        state = {}
+        return state

--- a/prompting/organic/synth_organic_task.py
+++ b/prompting/organic/synth_organic_task.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from prompting.organic.organic_task import OrganicTask
+
+
+@dataclass
+class SynthOrganicTask(OrganicTask):
+    """Task with defined reward and penalty mechanisms for synthetic organic prompts."""
+
+    name = "synthetic-organic"
+
+    reward_definition = [
+        dict(name="relevance", weight=0.8),
+        dict(name="rouge", ngram="rouge-1", metric="f", weight=0.2),
+    ]
+
+    penalty_definition = [
+        dict(name="relevance", weight=0.5),
+    ]
+
+    cleaning_pipeline = []
+
+    def __init__(self, context: dict, reference: str):
+        self.context = context
+        self.messages = context["messages"]
+        self.roles = context["roles"]
+        self.query = context["messages"][-1]
+        self.topic = "Organic"
+        self.reference = reference
+        self.subtopic = ""
+        self.tags = [""]

--- a/prompting/tasks/qa.py
+++ b/prompting/tasks/qa.py
@@ -92,7 +92,7 @@ class QuestionAnsweringTask(Task):
             self.query_prompt = FOLLOWUP_PROMPT_TEMPLATE.format(context=context.content, history=history)
             bt.logging.warning(f'Using history!!\n{history=}\n\n{context=}\n\n{self.query_prompt=}')
         else:
-            self.query_prompt = QUERY_PROMPT_TEMPLATE.format(context=context.content)            
+            self.query_prompt = QUERY_PROMPT_TEMPLATE.format(context=context.content)
             
         self.query = self.generate_query(llm_pipeline)
 

--- a/prompting/tasks/summarization.py
+++ b/prompting/tasks/summarization.py
@@ -43,7 +43,7 @@ class SummarizationTask(Task):
         self.context = context
 
         # Query is just the article title and section name
-        self.query = context.title + ", " + context.topic
+        self.query = context.title
 
         self.reference_prompt = REFERENCE_PROMPT_TEMPLATE.format(
             context=context.content

--- a/prompting/tools/datasets/base.py
+++ b/prompting/tools/datasets/base.py
@@ -73,7 +73,7 @@ class Dataset(ABC):
             tries += 1
             if tries >= self.max_tries:
                 raise MaxRetryError(
-                    f"Could not find any samples which meet {self.__class__.__name__} requirements after {tries} tries."
+                    f"Could not find any samples which meet {self.__class__.__name__} requirements after {info} tries."
                 )
 
         info["source"] = self.__class__.__name__

--- a/prompting/tools/datasets/wiki.py
+++ b/prompting/tools/datasets/wiki.py
@@ -116,7 +116,11 @@ def process_page(
         return ("Full Page", "\n\n".join(sections.values())) , sections.keys()
 
     valid_sections = [(key, value) for key, value in sections.items() if not valid_section or valid_section(sections[key])]
-    return selector(valid_sections), sections.keys()
+
+    if valid_sections:
+        return selector(valid_sections), sections.keys()
+    else:
+        return None, sections.keys()
 
 
 def most_relevant_links(page: wiki.WikipediaPage, num_links=10, num_summary_words=50, return_scores=False) -> List:

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -294,11 +294,19 @@ def add_validator_args(cls, parser):
         help="The tasks to use for the validator.",
         default=list(TASKS.keys()),
     )
+    import argparse
 
+    def parse_probabilities(prob_list):
+        try:
+            # Convert each item in the list to a float
+            return [float(p) for p in prob_list]
+        except ValueError:
+            raise argparse.ArgumentTypeError("All probabilities must be floats.")
+        
     parser.add_argument(
         "--neuron.task_p",
-        type=float,
-        nargs="+",
+        type=parse_probabilities,  # Use the custom parsing function
+        nargs="+",  # Allow multiple values
         help="The probability of sampling each task.",
         default=[1.0 / len(TASKS)] * len(TASKS),
     )

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -404,6 +404,106 @@ def add_validator_args(cls, parser):
         default=120,
     )
 
+    parser.add_argument(
+        "--neuron.organic_sample_size",
+        type=int,
+        help="The number of miners to organic query in a single step.",
+        default=5,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_sampling_mode",
+        type=str,
+        help="The mode for sampling miners using organic queries. Options include 'random' for random selection, "
+            "'top_incentive' for selecting based on highest incentives.",
+        default="random",
+    )
+
+    parser.add_argument(
+        "--neuron.organic_disabled",
+        action="store_true",
+        help="Set this flag to disable organic scoring.",
+        default=False,
+    )
+
+    # TODO: Set organic weight setting enabled by default after Aug 1, 2024.
+    parser.add_argument(
+        "--neuron.organic_set_weights_enabled",
+        action="store_true",
+        help="Set this flag to enable organic scoring weight setting.",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_synth_reward_scale",
+        type=float,
+        help="Scale factor for synthetic organic rewards.",
+        default=0.1,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_reuse_response_disabled",
+        action="store_true",
+        help="If set, miner responses will be re-generated during reward generation. "
+             "The default behavior is to reuse responses.",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_timeout",
+        type=int,
+        help="Organic query timeout for each call in seconds.",
+        default=30,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_reference_max_tokens",
+        type=int,
+        help="Organic query timeout for each call in seconds.",
+        default=1024,
+    )
+
+    # TODO: Increase sampling rate after after Aug 1, 2024.
+    parser.add_argument(
+        "--neuron.organic_trigger_frequency",
+        type=float,
+        help="Organic query sampling frequency (seconds or steps value).",
+        default=120.0,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_trigger_frequency_min",
+        type=float,
+        help="Minimum organic query sampling frequency (seconds or steps value).",
+        default=5.0,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_scaling_factor",
+        type=float,
+        help=(
+            "The scaling factor to adjust the trigger frequency based on the size of the organic queue. "
+            "A higher value means the trigger frequency adjusts more slowly to the increase of organic queue size."
+        ),
+        default=1.0,
+    )
+
+    parser.add_argument(
+        "--neuron.organic_trigger",
+        type=str,
+        help="Organic query validation trigger mode (seconds or steps).",
+        default="seconds",
+    )
+
+    parser.add_argument(
+        "--neuron.organic_whitelist_hotkey",
+        type=str,
+        help="Allow request from specific hotkey. Defaults to OTF hotkey.",
+        # OTF hotkey.
+        default="5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+    )
+
+
 
 def config(cls):
     """

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -20,8 +20,12 @@ import os
 import torch
 import argparse
 import bittensor as bt
-from loguru import logger
+import logging
 from prompting.tasks import TASKS
+
+from bittensor.btlogging.defines import BITTENSOR_LOGGER_NAME
+
+logger = logging.getLogger(BITTENSOR_LOGGER_NAME)
 
 
 def check_config(cls, config: "bt.Config"):
@@ -42,20 +46,16 @@ def check_config(cls, config: "bt.Config"):
     if not os.path.exists(config.neuron.full_path):
         os.makedirs(config.neuron.full_path, exist_ok=True)
 
-    log_level_exists = "EVENTS" in logger._core.levels
-    if not config.neuron.dont_save_events and not log_level_exists:
+    if not config.neuron.dont_save_events:
         # Add custom event logger for the events.
-        logger.level("EVENTS", no=38, icon="📝")
-        logger.add(
-            os.path.join(config.neuron.full_path, "events.log"),
-            rotation=config.neuron.events_retention_size,
-            serialize=True,
-            enqueue=True,
-            backtrace=False,
-            diagnose=False,
-            level="EVENTS",
-            format="{time:YYYY-MM-DD at HH:mm:ss} | {level} | {message}",
+        event_handler = logging.FileHandler(
+            os.path.join(config.neuron.full_path, "events.log")
         )
+        event_handler.setLevel(38)  # Custom level
+        formatter = logging.Formatter("{asctime} | {levelname} | {message}", style="{")
+        event_handler.setFormatter(formatter)
+        logger.addHandler(event_handler)
+        logging.addLevelName(38, "EVENTS")
 
 
 def add_args(cls, parser):
@@ -71,14 +71,14 @@ def add_args(cls, parser):
         help="Device to run on.",
         default="cuda" if torch.cuda.is_available() else "cpu",
     )
-    
+
     parser.add_argument(
         "--neuron.gpus",
         type=int,
         help="The number of visible GPUs to be considered in the llm initialization. This parameter currently reflects on the property `tensor_parallel_size` of vllm",
         default=1,
     )
-    
+
     parser.add_argument(
         "--neuron.llm_max_allowed_memory_in_gb",
         type=int,
@@ -396,7 +396,7 @@ def add_validator_args(cls, parser):
         help="Only query a single hotkey per ip.",
         default=False,
     )
-    
+
     parser.add_argument(
         "--neuron.forward_max_time",
         type=int,

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -373,14 +373,14 @@ def add_validator_args(cls, parser):
         "--wandb.project_name",
         type=str,
         help="The name of the project where you are sending the new run.",
-        default="alpha-validators",
+        default="prompting-validators",
     )
 
     parser.add_argument(
         "--wandb.entity",
         type=str,
         help="The name of the project where you are sending the new run.",
-        default="opentensor-dev",
+        default="macrocosmos",
     )
 
     parser.add_argument(

--- a/prompting/utils/exceptions.py
+++ b/prompting/utils/exceptions.py
@@ -4,3 +4,10 @@ class MaxRetryError(Exception):
     def __init__(self, message="Maximum number of retries exceeded"):
         self.message = message
         super().__init__(self.message)
+
+class BittensorError(Exception):
+    """Exception raised when an error is raised from the bittensor package"""
+
+    def __init__(self, message = "An error from the Bittensor package occured"):
+        self.message = message 
+        super().__init__(self.message)

--- a/prompting/utils/logging.py
+++ b/prompting/utils/logging.py
@@ -6,8 +6,11 @@ import bittensor as bt
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import List
-from loguru import logger
+import logging
 import prompting
+from bittensor.btlogging.defines import BITTENSOR_LOGGER_NAME
+
+logger = logging.getLogger(BITTENSOR_LOGGER_NAME)
 
 
 @dataclass
@@ -103,7 +106,7 @@ def reinit_wandb(self):
 
 def log_event(self, event):
     if not self.config.neuron.dont_save_events:
-        logger.log("EVENTS", "events", **event)
+        logger.log(38, "events", **event)
 
     if self.config.wandb.off:
         return

--- a/prompting/utils/logging.py
+++ b/prompting/utils/logging.py
@@ -106,7 +106,7 @@ def reinit_wandb(self):
 
 def log_event(self, event):
     if not self.config.neuron.dont_save_events:
-        logger.log(38, "events", **event)
+        logger.log(38, event)
 
     if self.config.wandb.off:
         return

--- a/prompting/utils/misc.py
+++ b/prompting/utils/misc.py
@@ -23,6 +23,7 @@ import bittensor as bt
 from math import floor
 from typing import Callable, Any
 from functools import lru_cache, update_wrapper
+from prompting.utils.exceptions import BittensorError
 
 
 # LRU Cache with TTL
@@ -110,7 +111,10 @@ def ttl_get_block(self) -> int:
 
     Note: self here is the miner or validator instance
     """
-    return self.subtensor.get_current_block()
+    try:
+        return self.subtensor.get_current_block()
+    except Exception as e:
+        raise BittensorError(f"Bittensor error: {str(e)}") from e
 
 
 def async_log(func):

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -1,7 +1,9 @@
 import torch
 import random
 import bittensor as bt
-from typing import List
+from typing import List, Union
+
+from prompting.base.neuron import BaseNeuron
 
 
 def check_uid_availability(
@@ -43,7 +45,7 @@ def check_uid_availability(
     return True
 
 
-def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor:
+def get_random_uids(self: BaseNeuron, k: int, exclude: List[int] = None) -> torch.LongTensor:
     """Returns k available random uids from the metagraph.
     Args:
         k (int): Number of uids to return.
@@ -89,3 +91,34 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
         return torch.tensor(random.sample(candidate_uids, k))
     else:
         raise ValueError(f"No eligible uids were found. Cannot return {k} uids")
+
+
+def get_top_incentive_uids(self, k: int, vpermit_tao_limit: int) -> torch.LongTensor:
+    metagraph = self.metagraph
+    miners_uids = list(map(int, filter(lambda uid: check_uid_availability(metagraph, uid, vpermit_tao_limit),
+        metagraph.uids)))
+    
+    # Builds a dictionary of uids and their corresponding incentives.
+    all_miners_incentives = {
+        "miners_uids": miners_uids,
+        "incentives": list(map(lambda uid: metagraph.I[uid], miners_uids))
+    }
+    
+    # Zip the uids and their corresponding incentives into a list of tuples.
+    uid_incentive_pairs = list(zip(all_miners_incentives["miners_uids"], all_miners_incentives["incentives"]))
+
+    # Sort the list of tuples by the incentive value in descending order.
+    uid_incentive_pairs_sorted = sorted(uid_incentive_pairs, key=lambda x: x[1], reverse=True)
+
+    # Extract the top uids.
+    top_k_uids = [uid for uid, incentive in uid_incentive_pairs_sorted[:k]]
+    
+    return torch.tensor(top_k_uids)
+
+
+def get_uids(self: BaseNeuron, sampling_mode: str, k: int, exclude: List[int] = []) -> torch.LongTensor:
+    if sampling_mode == "random":
+        return get_random_uids(self, k=k, exclude=exclude or [])
+    if sampling_mode == "top_incentive":
+        vpermit_tao_limit = self.config.neuron.vpermit_tao_limit
+        return get_top_incentive_uids(self, k=k, vpermit_tao_limit=vpermit_tao_limit)

--- a/prompting/validator.py
+++ b/prompting/validator.py
@@ -1,7 +1,8 @@
 import bittensor as bt
+
+from prompting.base.validator import BaseValidatorNeuron
 from prompting.forward import forward
 from prompting.llms import vLLMPipeline
-from prompting.base.validator import BaseValidatorNeuron
 from prompting.rewards import RewardPipeline
 from prompting.tasks.translate import TranslationPipeline
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ argostranslate==1.9.6
 python-dotenv
 wikipedia_sections
 vllm
-loguru
 argostranslate
 transformers==4.41.2
 autoawq==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,6 @@ wikipedia_sections==2.0.0
 vllm==0.4.3
 loguru==0.7.2
 argostranslate==1.9.6
-python-dotenv
-wikipedia_sections
-vllm
-argostranslate
 transformers==4.41.2
 autoawq==0.2.5
+git+https://github.com/macrocosm-os/organic-scoring.git@main

--- a/tests/fixtures/dataset.py
+++ b/tests/fixtures/dataset.py
@@ -14,12 +14,15 @@ DATASETS = [
     MathDataset,
 ]
 
+def select_first(list):
+    return list[0]
 
 MOCK_CONTEXT = MockDataset().next()
-WIKI_CONTEXT = WikiDataset().next(name="Emilio Alvarez (bishop)", method="get")
+WIKI_CONTEXT= WikiDataset().next(name="Emilio Alvarez (bishop)", method="get", selector=select_first)
 CODING_CONTEXT = HFCodingDataset(buffer_size=1, seed=42).next()
 MATH_CONTEXT = MathDataset(seed=123).next()
 DATEQA_CONTEXT = WikiDateDataset(seed=123).next()
+
 
 CONTEXTS = {
     MockDataset: MOCK_CONTEXT,


### PR DESCRIPTION
## Change notes
  - Organic Scoring @dbobrenko :
    - Runs concurrently with benchmarking tasks;
    - Incoming requests are received by validators via served axon;
    - Miner's responses are rewarded based on Relevance and Rouge;
    - Set weights for organic scoring is disabled;
    - In order to fully run Organic Scoring, validators should log in to the HuggingFace and accept LMSys Chat License Agreement;
    - Synthetic organic dataset is optional, if it failed to fetch HuggingFace data.
  - New dependency package: [organic-scoring](git+https://github.com/macrocosm-os/organic-scoring.git@main);
  - Fix Wiki package errors @bkb2135;
  - Restart validator on Bittensor error (`get_block`) @bkb2135;
  - Documentation improvements;
  - Other minor fixes.