### PR TITLE
Utiliize random.choice when calling random() on the wiki dataset

### DIFF
--- a/prompting/tools/datasets/wiki.py
+++ b/prompting/tools/datasets/wiki.py
@@ -232,7 +232,7 @@ class WikiDataset(Dataset):
 
     def random(self, pages=10, seed=None, selector: Selector = None, **kwargs) -> Dict:
         titles = wiki.random(pages=pages) if seed is None else _get_random_titles(pages=pages, seed=seed)
-        title = selector(titles)
+        title = random.choice(titles)
         return self.get(title, selector=selector)
 
 


### PR DESCRIPTION
Currently WikiDataset.random() actually did not allow for any selector other than one which selects a single entry from a list. Now it will default to random.choice()