### PR TITLE
Enable organic weight set, fix WASM errors

### DIFF
--- a/prompting/organic/organic_scoring_prompting.py
+++ b/prompting/organic/organic_scoring_prompting.py
@@ -305,8 +305,8 @@ class OrganicScoringPrompting(OrganicScoringBase):
 
         uids_to_reward = dict(zip(uids, reward_result.rewards))
         bt.logging.info(f"[Organic] Rewards for miner's UIDs: {uids_to_reward}")
-        bt.logging.info(f"[Organic] Weight setting disabled: {self._val.config.neuron.organic_set_weights_disabled}")
-        if not self._val.config.neuron.organic_set_weights_disabled:
+        bt.logging.info(f"[Organic] Weight setting disabled: {self._val.config.neuron.organic_disable_set_weights}")
+        if not self._val.config.neuron.organic_disable_set_weights:
             self._val.update_scores(reward_result.rewards, uids)
             # Sync is not needed as it's done in the benchmarks loop.
             # self._val.sync()

--- a/prompting/organic/organic_scoring_prompting.py
+++ b/prompting/organic/organic_scoring_prompting.py
@@ -305,8 +305,8 @@ class OrganicScoringPrompting(OrganicScoringBase):
 
         uids_to_reward = dict(zip(uids, reward_result.rewards))
         bt.logging.info(f"[Organic] Rewards for miner's UIDs: {uids_to_reward}")
-        bt.logging.info(f"[Organic] Weight setting enabled: {self._val.config.neuron.organic_set_weights_enabled}")
-        if self._val.config.neuron.organic_set_weights_enabled:
+        bt.logging.info(f"[Organic] Weight setting disabled: {self._val.config.neuron.organic_set_weights_disabled}")
+        if not self._val.config.neuron.organic_set_weights_disabled:
             self._val.update_scores(reward_result.rewards, uids)
             # Sync is not needed as it's done in the benchmarks loop.
             # self._val.sync()

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -434,7 +434,6 @@ def add_validator_args(cls, parser):
         default=False,
     )
 
-    # TODO: Set organic weight setting enabled by default after Aug 1, 2024.
     parser.add_argument(
         "--neuron.organic_set_weights_disabled",
         action="store_true",
@@ -471,7 +470,6 @@ def add_validator_args(cls, parser):
         default=1024,
     )
 
-    # TODO: Increase sampling rate after after Aug 1, 2024.
     parser.add_argument(
         "--neuron.organic_trigger_frequency",
         type=float,

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -430,14 +430,14 @@ def add_validator_args(cls, parser):
     parser.add_argument(
         "--neuron.organic_disabled",
         action="store_true",
-        help="Set this flag to disable organic scoring.",
+        help="Disables organic scoring.",
         default=False,
     )
 
     parser.add_argument(
-        "--neuron.organic_set_weights_disabled",
+        "--neuron.organic_disable_set_weights",
         action="store_true",
-        help="Set this flag to enable organic scoring weight setting.",
+        help="Disables organic scoring weight setting.",
         default=False,
     )
 

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -436,7 +436,7 @@ def add_validator_args(cls, parser):
 
     # TODO: Set organic weight setting enabled by default after Aug 1, 2024.
     parser.add_argument(
-        "--neuron.organic_set_weights_enabled",
+        "--neuron.organic_set_weights_disabled",
         action="store_true",
         help="Set this flag to enable organic scoring weight setting.",
         default=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 angle_emb==0.4.4
-bittensor==7.1.1
+git+https://github.com/opentensor/bittensor.git@release/7.1.2#egg=bittensor
 bs4==0.0.2
 click==8.1.3
 datasets==2.14.6


### PR DESCRIPTION
## Changes

- Enable organic scoring weight setting.
- Fix bittensor WASM errors by switching to another bittensor branch.