### PR TITLE
Fix mixture endpoint

### DIFF
--- a/validator_api/chat_completion.py
+++ b/validator_api/chat_completion.py
@@ -92,7 +92,7 @@ async def get_response_from_miner(body: dict[str, any], uid: int) -> tuple:
 
 
 async def chat_completion(
-    body: dict[str, any], uids: Optional[int] = None, num_miners: int = 3
+    body: dict[str, any], uids: Optional[list[int]] = None, num_miners: int = 3
 ) -> tuple | StreamingResponse:
     """Handle chat completion with multiple miners in parallel."""
     # Get multiple UIDs if none specified

--- a/validator_api/mixture_of_miners.py
+++ b/validator_api/mixture_of_miners.py
@@ -22,7 +22,7 @@ TASK_SYSTEM_PROMPT = {
     # Add more task-specific system prompts here.
 }
 
-NUM_MIXTURE_MINERS = 5
+NUM_MIXTURE_MINERS = 8
 TOP_INCENTIVE_POOL = 100
 
 
@@ -67,7 +67,7 @@ async def mixture_of_miners(body: dict[str, any]) -> tuple | StreamingResponse:
         raise HTTPException(status_code=503, detail="Failed to get responses from miners")
 
     # Extract completions from the responses.
-    completions = [response[1][0] for response in valid_responses if response and len(response) > 1]
+    completions = ["".join(response[1]) for response in valid_responses if response and len(response) > 1]
 
     task_name = body.get("task")
     system_prompt = TASK_SYSTEM_PROMPT.get(task_name, DEFAULT_SYSTEM_PROMPT)
@@ -85,4 +85,4 @@ async def mixture_of_miners(body: dict[str, any]) -> tuple | StreamingResponse:
 
     # Get final response using a random top miner.
     final_uid = random.choice(get_uids(sampling_mode="top_incentive", k=TOP_INCENTIVE_POOL))
-    return await chat_completion(final_body, final_uid)
+    return await chat_completion(final_body, uids=[int(final_uid)])


### PR DESCRIPTION
## Changes
  - Fix mixture endpoint to take into account full completions.

## Example from live test
Query: `Say 10 random numbers between 1 and 100` with `mixture=True`:
```
It seems like all the models have generated the same list of 10 random numbers between 1 and 100. Here is the synthesized response:

Here are 10 random numbers between 1 and 100:

1. 43
2. 91
3. 14
4. 67
5. 85
6. 28
7. 52
8. 19
9. 73
10. 41
```