### PR TITLE
Set AWQ version to 2.7.3.post3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,10 @@ poetry config virtualenvs.in-project true
 # Install the project dependencies
 poetry install --extras "validator"
 
-# Build AutoAWQ==0.2.7.post3 from source
+# Build AutoAWQ==0.2.8 from source
 git clone https://github.com/casper-hansen/AutoAWQ.git
-cd AutoAWQ  && poetry run pip install -e . && cd ..
+cd AutoAWQ && git checkout 16335d087dd4f9cdc8933dd7a5681e4bf88311b6 && poetry run pip install -e . && cd ..
+rm -r AutoAWQ
 
 poetry run pip install flash-attn --no-build-isolation
 

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,9 @@ poetry config virtualenvs.in-project true
 # Install the project dependencies
 poetry install --extras "validator"
 
-# Build AutoAWQ==0.2.8 from source
+# Build AutoAWQ==0.2.7.post3 from source
 git clone https://github.com/casper-hansen/AutoAWQ.git
-cd AutoAWQ && git checkout 16335d087dd4f9cdc8933dd7a5681e4bf88311b6 && poetry run pip install -e . && cd ..
+cd AutoAWQ && git checkout cbd6a75b065e94a3e530dfdbb8f3973f0d954ec0 && poetry run pip install -e . && cd ..
 rm -r AutoAWQ
 
 poetry run pip install flash-attn --no-build-isolation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prompting"
-version = "2.16.2"
+version = "2.16.3"
 description = "Subnetwork 1 runs on Bittensor and is maintained by Macrocosmos. It's an effort to create decentralised AI"
 authors = ["Kalei Brady, Dmytro Bobrenko, Felix Quinque, Steffen Cruz, Richard Wardle"]
 readme = "README.md"


### PR DESCRIPTION
## Hotfix
  - Latest AutoAWQ 2.8.0 causes: `ImportError: cannot import name 'shard_checkpoint' from 'transformers.modeling_utils'`.