### PR TITLE
Hotfix HF model initialization

### DIFF
--- a/neurons/miners/epistula_miner/miner.py
+++ b/neurons/miners/epistula_miner/miner.py
@@ -45,7 +45,11 @@ class OpenAIMiner:
             },
         )
         if SHOULD_SERVE_LLM:
-            self.llm = ReproducibleHF(model_id=LOCAL_MODEL_ID)
+            self.llm = ReproducibleHF(
+                model_id=LOCAL_MODEL_ID,
+                device=settings.NEURON_DEVICE,
+                sampling_params=settings.SAMPLING_PARAMS,
+            )
         else:
             self.llm = None
 

--- a/neurons/miners/epistula_miner/miner.py
+++ b/neurons/miners/epistula_miner/miner.py
@@ -47,8 +47,8 @@ class OpenAIMiner:
         if SHOULD_SERVE_LLM:
             self.llm = ReproducibleHF(
                 model_id=LOCAL_MODEL_ID,
-                device=settings.NEURON_DEVICE,
-                sampling_params=settings.SAMPLING_PARAMS,
+                device=shared_settings.NEURON_DEVICE,
+                sampling_params=shared_settings.SAMPLING_PARAMS,
             )
         else:
             self.llm = None

--- a/prompting/llms/hf_llm.py
+++ b/prompting/llms/hf_llm.py
@@ -7,11 +7,11 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, p
 
 class ReproducibleHF:
     def __init__(
-            self,
-            model_id: str = "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
-            device: str = "cuda:0",
-            sampling_params: dict[str, str | float | int | bool] | None = None,
-        ):
+        self,
+        model_id: str = "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+        device: str = "cuda:0",
+        sampling_params: dict[str, str | float | int | bool] | None = None,
+    ):
         """Deterministic HuggingFace model."""
         self._device = device
         self.sampling_params = {} if sampling_params is None else sampling_params
@@ -30,11 +30,11 @@ class ReproducibleHF:
 
     @torch.inference_mode()
     def generate(
-            self,
-            messages: list[str] | list[dict[str, str]],
-            sampling_params: dict[str, str | float | int | bool] | None = None,
-            seed: int | None = None,
-        ) -> str:
+        self,
+        messages: list[str] | list[dict[str, str]],
+        sampling_params: dict[str, str | float | int | bool] | None = None,
+        seed: int | None = None,
+    ) -> str:
         """Generate text with optimized performance."""
         self.set_random_seeds(seed)
 

--- a/prompting/llms/hf_llm.py
+++ b/prompting/llms/hf_llm.py
@@ -4,38 +4,38 @@ import numpy as np
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, pipeline
 
-from shared.settings import shared_settings
-
 
 class ReproducibleHF:
-    def __init__(self, model_id="hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4", **kwargs):
-        """
-        Initialize Hugging Face model with reproducible settings and optimizations
-        """
-        # Create a random seed for reproducibility
-        # self.seed = random.randint(0, 1_000_000)
-        # self.set_random_seeds(self.seed)
+    def __init__(
+            self,
+            model_id: str = "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+            device: str = "cuda:0",
+            sampling_params: dict[str, str | float | int | bool] | None = None,
+        ):
+        """Deterministic HuggingFace model."""
+        self._device = device
+        self.sampling_params = {} if sampling_params is None else sampling_params
         self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
             model_id,
             torch_dtype=torch.float16,
             low_cpu_mem_usage=True,
-            device_map="cuda:0",
+            device_map=self._device,
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         self.valid_generation_params = set(
             AutoModelForCausalLM.from_pretrained(model_id).generation_config.to_dict().keys()
         )
-
         self.llm = pipeline("text-generation", model=self.model, tokenizer=self.tokenizer)
 
-        self.sampling_params = shared_settings.SAMPLING_PARAMS
-
     @torch.inference_mode()
-    def generate(self, messages: list[str] | list[dict], sampling_params=None, seed=None):
-        """
-        Generate text with optimized performance
-        """
+    def generate(
+            self,
+            messages: list[str] | list[dict[str, str]],
+            sampling_params: dict[str, str | float | int | bool] | None = None,
+            seed: int | None = None,
+        ) -> str:
+        """Generate text with optimized performance."""
         self.set_random_seeds(seed)
 
         inputs = self.tokenizer.apply_chat_template(
@@ -44,14 +44,13 @@ class ReproducibleHF:
             add_generation_prompt=True,
             return_tensors="pt",
             return_dict=True,
-        ).to(shared_settings.NEURON_DEVICE)
+        ).to(self._device)
 
         params = sampling_params if sampling_params else self.sampling_params
         filtered_params = {k: v for k, v in params.items() if k in self.valid_generation_params}
 
-        # Generate with optimized settings
         outputs = self.model.generate(
-            **inputs.to(shared_settings.NEURON_DEVICE),
+            **inputs,
             **filtered_params,
             eos_token_id=self.tokenizer.eos_token_id,
         )
@@ -61,21 +60,10 @@ class ReproducibleHF:
             skip_special_tokens=True,
         )[0]
 
-        # logger.debug(
-        #     f"""{self.__class__.__name__} queried:
-        #     prompt: {messages}\n
-        #     responses: {results}\n
-        #     sampling params: {params}\n
-        #     seed: {seed}
-        #     """
-        # )
-
         return results if len(results) > 1 else results[0]
 
-    def set_random_seeds(self, seed=42):
-        """
-        Set random seeds for reproducibility across all relevant libraries
-        """
+    def set_random_seeds(self, seed: int | None = 42):
+        """Set random seeds for reproducibility across all relevant libraries."""
         if seed is not None:
             random.seed(seed)
             np.random.seed(seed)

--- a/prompting/llms/model_manager.py
+++ b/prompting/llms/model_manager.py
@@ -65,9 +65,9 @@ class ModelManager(BaseModel):
             GPUInfo.log_gpu_info()
 
             model = ReproducibleHF(
-                model=model_config.llm_model_id,
-                gpu_memory_utilization=model_config.min_ram / GPUInfo.free_memory,
-                max_model_len=settings.shared_settings.LLM_MAX_MODEL_LEN,
+                model_id=model_config.llm_model_id,
+                device=settings.NEURON_DEVICE,
+                sampling_params=settings.SAMPLING_PARAMS,
             )
 
             self.active_models[model_config] = model

--- a/prompting/llms/model_manager.py
+++ b/prompting/llms/model_manager.py
@@ -66,8 +66,8 @@ class ModelManager(BaseModel):
 
             model = ReproducibleHF(
                 model_id=model_config.llm_model_id,
-                device=settings.NEURON_DEVICE,
-                sampling_params=settings.SAMPLING_PARAMS,
+                device=settings.shared_settings.NEURON_DEVICE,
+                sampling_params=settings.shared_settings.SAMPLING_PARAMS,
             )
 
             self.active_models[model_config] = model

--- a/prompting/rewards/web_retrieval.py
+++ b/prompting/rewards/web_retrieval.py
@@ -66,7 +66,7 @@ try:
         logger.warning(f"Past websites file {PAST_WEBSITES_FILE} does not exist or empty, creating new dictionary")
         past_websites = defaultdict(list)
 except Exception as e:
-    logger.exception(f"Failed to load domains data: {e}")
+    logger.error(f"Failed to load domains data: {e}")
     TOP_DOMAINS = set()
     past_websites = defaultdict(list)
 

--- a/prompting/tasks/qa.py
+++ b/prompting/tasks/qa.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from prompting.datasets.random_website import DDGDatasetEntry
 from prompting.rewards.relevance import RelevanceRewardModel
 from prompting.rewards.reward import BaseRewardConfig, BaseRewardModel
 from prompting.rewards.rouge import RougeRewardModel
@@ -80,12 +81,12 @@ class WebQuestionAnsweringTask(BaseTextTask):
     query: str | None = None
     reference: str | None = None
 
-    def make_query(self, dataset_entry: Context):
+    def make_query(self, dataset_entry: DDGDatasetEntry):
         query_prompt = QUERY_PROMPT_TEMPLATE.format(context=dataset_entry.website_content)
         self.query = self.generate_query(messages=[query_prompt])
         return self.query
 
-    async def make_reference(self, dataset_entry: Context):
+    async def make_reference(self, dataset_entry: DDGDatasetEntry):
         reference_prompt = REFERENCE_PROMPT_TEMPLATE.format(context=dataset_entry.website_content, question=self.query)
         self.reference = self.generate_reference(messages=[{"role": "user", "content": reference_prompt}])
         return self.reference


### PR DESCRIPTION
## Changes
  - Hotfix HF model initialization by respecting specified model ID, caused by suppressing error with `**kwargs` in model constructor. 
  - Use specified model device instead of hard-coded `cuda:0`.
  - Decouple HF model from settings.
  - Remove redundant params passed to HF.
  - Fix typings.